### PR TITLE
Show last saved battery in notification

### DIFF
--- a/android/app/src/main/java/me/kavishdevar/aln/BatteryWidget.kt
+++ b/android/app/src/main/java/me/kavishdevar/aln/BatteryWidget.kt
@@ -56,27 +56,27 @@ internal fun updateAppWidget(
 
     views.setTextViewText(R.id.left_battery_widget,
         batteryList?.find { it.component == BatteryComponent.LEFT }?.let {
-            if (it.status != BatteryStatus.DISCONNECTED) {
+            // if (it.status != BatteryStatus.DISCONNECTED) {
                 "${if (it.status == BatteryStatus.CHARGING) "⚡" else ""} ${it.level}%"
-            } else {
-                ""
-            }
+            // } else {
+            //     ""
+            // }
         } ?: "")
     views.setTextViewText(R.id.right_battery_widget,
         batteryList?.find { it.component == BatteryComponent.RIGHT }?.let {
-            if (it.status != BatteryStatus.DISCONNECTED) {
+            // if (it.status != BatteryStatus.DISCONNECTED) {
                 "${if (it.status == BatteryStatus.CHARGING) "⚡" else ""} ${it.level}%"
-            } else {
-                ""
-            }
+            // } else {
+            //     ""
+            // }
         } ?: "")
     views.setTextViewText(R.id.case_battery_widget,
         batteryList?.find { it.component == BatteryComponent.CASE }?.let {
-            if (it.status != BatteryStatus.DISCONNECTED) {
+            // if (it.status != BatteryStatus.DISCONNECTED) {
                 "${if (it.status == BatteryStatus.CHARGING) "⚡" else ""} ${it.level}%"
-            } else {
-                ""
-            }
+            // } else {
+            //     ""
+            // }
         } ?: "")
 
     appWidgetManager.updateAppWidget(appWidgetId, views)

--- a/android/app/src/main/java/me/kavishdevar/aln/services/AirPodsService.kt
+++ b/android/app/src/main/java/me/kavishdevar/aln/services/AirPodsService.kt
@@ -262,23 +262,23 @@ class AirPodsService: Service() {
             updatedNotification = NotificationCompat.Builder(this, "background_service_status")
                 .setSmallIcon(R.drawable.airpods)
                 .setContentTitle("""AirPods  –${batteryList?.find { it.component == BatteryComponent.LEFT }?.let {
-                    if (it.status != BatteryStatus.DISCONNECTED) {
+                    // if (it.status != BatteryStatus.DISCONNECTED) {
                         "  L:${if (it.status == BatteryStatus.CHARGING) "⚡" else ""} ${it.level}%"
-                    } else {
-                        ""
-                    }
+                    // } else {
+                    //     ""
+                    // }
                 } ?: ""}${batteryList?.find { it.component == BatteryComponent.RIGHT }?.let {
-                    if (it.status != BatteryStatus.DISCONNECTED) {
+                    // if (it.status != BatteryStatus.DISCONNECTED) {
                         "  R:${if (it.status == BatteryStatus.CHARGING) "⚡" else ""} ${it.level}%"
-                    } else {
-                        ""
-                    }
+                    // } else {
+                    //     ""
+                    // }
                 } ?: ""}${batteryList?.find { it.component == BatteryComponent.CASE }?.let {
-                    if (it.status != BatteryStatus.DISCONNECTED) {
+                    // if (it.status != BatteryStatus.DISCONNECTED) {
                         "  C:${if (it.status == BatteryStatus.CHARGING) "⚡" else ""} ${it.level}%"
-                    } else {
-                        ""
-                    }
+                    // } else {
+                    //     ""
+                    // }
                 } ?: ""}""")
                 .setCategory(Notification.CATEGORY_SERVICE)
                 .setPriority(NotificationCompat.PRIORITY_LOW)


### PR DESCRIPTION
Update `AirPodsService.kt` and `BatteryWidget.kt` to retain and display the last received battery levels when the case or bud gets disconnected.

* **AirPodsService.kt**
  - Comment out the condition that sets battery levels to an empty string if the status is `BatteryStatus.DISCONNECTED`.

* **BatteryWidget.kt**
  - Comment out the condition that sets battery levels to an empty string if the status is `BatteryStatus.DISCONNECTED`.