### PR TITLE
[Linux] Use a enum to control the noise control mode

### DIFF
--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -52,6 +52,18 @@ class AirPodsTrayApp : public QObject {
     Q_OBJECT
 
 public:
+    enum NoiseControlMode : quint8
+    {
+        Off = 0,
+        NoiseCancellation = 1,
+        Transparency = 2,
+        Adaptive = 3,
+
+        MinValue = Off,
+        MaxValue = Adaptive,
+    };
+    Q_ENUM(NoiseControlMode)
+
     AirPodsTrayApp(bool debugMode) : debugMode(debugMode) {
         if (debugMode) {
             QLoggingCategory::setFilterRules("airpodsApp.debug=true");
@@ -79,6 +91,11 @@ public:
         QAction *adaptiveAction = new QAction("Adaptive", trayMenu);
         QAction *noiseCancellationAction = new QAction("Noise Cancellation", trayMenu);
 
+        offAction->setData(NoiseControlMode::Off);
+        transparencyAction->setData(NoiseControlMode::Transparency);
+        adaptiveAction->setData(NoiseControlMode::Adaptive);
+        noiseCancellationAction->setData(NoiseControlMode::NoiseCancellation);
+
         offAction->setCheckable(true);
         transparencyAction->setCheckable(true);
         adaptiveAction->setCheckable(true);
@@ -95,10 +112,14 @@ public:
         noiseControlGroup->addAction(adaptiveAction);
         noiseControlGroup->addAction(noiseCancellationAction);
 
-        connect(offAction, &QAction::triggered, this, [this]() { setNoiseControlMode(0); });
-        connect(transparencyAction, &QAction::triggered, this, [this]() { setNoiseControlMode(2); });
-        connect(adaptiveAction, &QAction::triggered, this, [this]() { setNoiseControlMode(3); });
-        connect(noiseCancellationAction, &QAction::triggered, this, [this]() { setNoiseControlMode(1); });
+        connect(offAction, &QAction::triggered, this, [this]()
+                { setNoiseControlMode(NoiseControlMode::Off); });
+        connect(transparencyAction, &QAction::triggered, this, [this]()
+                { setNoiseControlMode(NoiseControlMode::Transparency); });
+        connect(adaptiveAction, &QAction::triggered, this, [this]()
+                { setNoiseControlMode(NoiseControlMode::Adaptive); });
+        connect(noiseCancellationAction, &QAction::triggered, this, [this]()
+                { setNoiseControlMode(NoiseControlMode::NoiseCancellation); });
 
         connect(this, &AirPodsTrayApp::noiseControlModeChanged, this, &AirPodsTrayApp::updateNoiseControlMenu);
         connect(this, &AirPodsTrayApp::batteryStatusChanged, this, &AirPodsTrayApp::updateBatteryTooltip);
@@ -274,20 +295,20 @@ public slots:
         }
     }
 
-    void setNoiseControlMode(int mode) {
+    void setNoiseControlMode(NoiseControlMode mode) {
         LOG_INFO("Setting noise control mode to: " << mode);
         QByteArray packet;
         switch (mode) {
-            case 0:
+            case Off:
                 packet = QByteArray::fromHex("0400040009000D01000000");
                 break;
-            case 1:
+            case NoiseCancellation:
                 packet = QByteArray::fromHex("0400040009000D02000000");
                 break;
-            case 2:
+            case Transparency:
                 packet = QByteArray::fromHex("0400040009000D03000000");
                 break;
-            case 3:
+            case Adaptive:
                 packet = QByteArray::fromHex("0400040009000D04000000");
                 break;
         }
@@ -310,24 +331,10 @@ public slots:
         }
     }
 
-    void updateNoiseControlMenu(int mode) {
+    void updateNoiseControlMenu(NoiseControlMode mode) {
         QList<QAction *> actions = trayMenu->actions();
         for (QAction *action : actions) {
-            action->setChecked(false);
-        }
-        switch (mode) {
-            case 0:
-                actions[0]->setChecked(true);
-                break;
-            case 1:
-                actions[3]->setChecked(true);
-                break;
-            case 2:
-                actions[1]->setChecked(true);
-                break;
-            case 3:
-                actions[2]->setChecked(true);
-                break;
+            action->setChecked(action->data().toInt() == mode);
         }
     }
 
@@ -577,12 +584,16 @@ public slots:
     void parseData(const QByteArray &data) {
         LOG_DEBUG("Received: " << data.toHex());
         if (data.size() == 11 && data.startsWith(QByteArray::fromHex("0400040009000D"))) {
-            int mode = data[7] - 1;
-            LOG_INFO("Noise control mode: " << mode);
-            if (mode >= 0 && mode <= 3) {
+            quint8 rawMode = data[7] - 1;
+            if (rawMode >= NoiseControlMode::MinValue && rawMode <= NoiseControlMode::MaxValue)
+            {
+                NoiseControlMode mode = static_cast<NoiseControlMode>(rawMode);
+                LOG_INFO("Noise control mode: " << rawMode);
                 emit noiseControlModeChanged(mode);
-            } else {
-                LOG_ERROR("Invalid noise control mode value received: " << mode);
+            }
+            else
+            {
+                LOG_ERROR("Invalid noise control mode value received: " << rawMode);
             }
         } else if (data.size() == 8 && data.startsWith(QByteArray::fromHex("040004000600"))) {
             char primary = data[6];
@@ -873,7 +884,7 @@ public slots:
     }
 
 signals:
-    void noiseControlModeChanged(int mode);
+    void noiseControlModeChanged(NoiseControlMode mode);
     void earDetectionStatusChanged(const QString &status);
     void batteryStatusChanged(const QString &status);
 


### PR DESCRIPTION
It's easier to read the name instead of a number.

Showing the correct battery level when only 1 airpod is connected also slippen in this branch, idk how this happended.