### PR TITLE
[Linux] Fix noise control switches multiple times

### DIFF
--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -225,6 +225,11 @@ public slots:
     void setNoiseControlMode(NoiseControlMode mode)
     {
         LOG_INFO("Setting noise control mode to: " << mode);
+        if (m_noiseControlMode == mode)
+        {
+            LOG_INFO("Noise control mode is already " << mode);
+            return;
+        }
         QByteArray packet = AirPodsPackets::NoiseControl::getPacketForMode(mode);
         writePacketToSocket(packet, "Noise control mode packet written: ");
     }


### PR DESCRIPTION
With only 1 airpod, it sometimes switched between the modes multiple times (@kavishdevar, you also reported this). This should fix it (at least it never occurred afterwards for me)