### PR TITLE
[Linux] CA state parsing, robuster handshake, persistent window

### DIFF
--- a/linux/Main.qml
+++ b/linux/Main.qml
@@ -2,10 +2,15 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 
 ApplicationWindow {
+    id: mainWindow
     visible: true
     width: 400
     height: 300
     title: "AirPods Settings"
+
+    onClosing: function(event) {
+        mainWindow.visible = false
+    }
 
     Column {
         anchors.left: parent.left

--- a/linux/airpods_packets.h
+++ b/linux/airpods_packets.h
@@ -38,10 +38,27 @@ namespace AirPodsPackets
     // Conversational Awareness Packets
     namespace ConversationalAwareness
     {
-        static const QByteArray HEADER = QByteArray::fromHex("04000400090028");          // Added for parsing
-        static const QByteArray ENABLED = HEADER + QByteArray::fromHex("01000000");
-        static const QByteArray DISABLED = HEADER + QByteArray::fromHex("02000000");
-        static const QByteArray DATA_HEADER = QByteArray::fromHex("040004004B00020001"); // For received data
+        static const QByteArray HEADER = QByteArray::fromHex("04000400090028");          // For command/status
+        static const QByteArray ENABLED = HEADER + QByteArray::fromHex("01000000");      // Command to enable
+        static const QByteArray DISABLED = HEADER + QByteArray::fromHex("02000000");     // Command to disable
+        static const QByteArray DATA_HEADER = QByteArray::fromHex("040004004B00020001"); // For received speech level data
+
+        static std::optional<bool> parseCAState(const QByteArray &data)
+        {
+            // Extract the status byte (index 7)
+            quint8 statusByte = static_cast<quint8>(data.at(HEADER.size())); // HEADER.size() is 7
+
+            // Interpret the status byte
+            switch (statusByte)
+            {
+            case 0x01: // Enabled
+                return true;
+            case 0x02: // Disabled
+                return false;
+            default:
+                return std::nullopt;
+            }
+        }
     }
 
     // Connection Packets

--- a/linux/airpods_packets.h
+++ b/linux/airpods_packets.h
@@ -188,6 +188,8 @@ namespace AirPodsPackets
         static const QByteArray EAR_DETECTION = QByteArray::fromHex("040004000600");
         static const QByteArray BATTERY_STATUS = QByteArray::fromHex("040004000400");
         static const QByteArray METADATA = QByteArray::fromHex("040004001d");
+        static const QByteArray HANDSHAKE_ACK = QByteArray::fromHex("01000400");
+        static const QByteArray FEATURES_ACK = QByteArray::fromHex("040004002b00"); // Note: Only tested with airpods pro 2
     }
 }
 

--- a/linux/ble/blescanner.cpp
+++ b/linux/ble/blescanner.cpp
@@ -90,6 +90,7 @@ BleScanner::BleScanner(QWidget *parent) : QMainWindow(parent)
     detailsLayout->addWidget(new QLabel("Raw Data:"), 7, 0);
     rawDataLabel = new QLabel(this);
     rawDataLabel->setWordWrap(true);
+    rawDataLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
     detailsLayout->addWidget(rawDataLabel, 7, 1, 1, 2);
 
     // New Rows for Additional Info

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -891,6 +891,7 @@ private:
 
 int main(int argc, char *argv[]) {
     QApplication app(argc, argv);
+    app.setQuitOnLastWindowClosed(false);
 
     bool debugMode = false;
     for (int i = 1; i < argc; ++i) {


### PR DESCRIPTION
This PR adds following features:

- [x] Parse Conversational Awareness state from the AirPods (instead of storing it locally)
- [x] Don't quit the app when we close the window
- [x] Extract MagicAccIRK and MagicAccEncKey
- [x] Add ability to disable cross-device (you need to manually edit the config file for now)
- [x] More robust handshake, notification request