### PR TITLE
[Linux] Implement proper disconnection detection

### DIFF
--- a/linux/BluetoothMonitor.cpp
+++ b/linux/BluetoothMonitor.cpp
@@ -1,0 +1,75 @@
+#include "BluetoothMonitor.h"
+#include <QDebug>
+
+BluetoothMonitor::BluetoothMonitor(QObject *parent) 
+    : QObject(parent), m_dbus(QDBusConnection::systemBus())
+{
+    if (!m_dbus.isConnected())
+    {
+        qWarning() << "Failed to connect to system D-Bus";
+        return;
+    }
+
+    registerDBusService();
+}
+
+BluetoothMonitor::~BluetoothMonitor()
+{
+    m_dbus.disconnectFromBus(m_dbus.name());
+}
+
+void BluetoothMonitor::registerDBusService()
+{
+    // Match signals for PropertiesChanged on any BlueZ Device interface
+    QString matchRule = QStringLiteral("type='signal',"
+                                       "interface='org.freedesktop.DBus.Properties',"
+                                       "member='PropertiesChanged',"
+                                       "path_namespace='/org/bluez'");
+
+    m_dbus.connect("org.freedesktop.DBus",
+                   "/org/freedesktop/DBus",
+                   "org.freedesktop.DBus",
+                   "AddMatch",
+                   this,
+                   SLOT(onPropertiesChanged(QString, QVariantMap, QStringList)));
+
+    if (!m_dbus.connect("", "", "org.freedesktop.DBus.Properties", "PropertiesChanged",
+                        this, SLOT(onPropertiesChanged(QString, QVariantMap, QStringList))))
+    {
+        qWarning() << "Failed to connect to D-Bus PropertiesChanged signal";
+    }
+}
+
+void BluetoothMonitor::onPropertiesChanged(const QString &interface, const QVariantMap &changedProps, const QStringList &invalidatedProps)
+{
+    Q_UNUSED(invalidatedProps);
+
+    if (interface != "org.bluez.Device1")
+    {
+        return;
+    }
+
+    if (changedProps.contains("Connected"))
+    {
+        bool connected = changedProps["Connected"].toBool();
+        QString path = QDBusContext::message().path();
+
+        QDBusInterface deviceInterface("org.bluez", path, "org.freedesktop.DBus.Properties", m_dbus);
+        QDBusReply<QVariant> reply = deviceInterface.call("Get", "org.bluez.Device1", "Address");
+
+        if (reply.isValid())
+        {
+            QString macAddress = reply.value().toString();
+            if (connected)
+            {
+                emit deviceConnected(macAddress);
+                qDebug() << "Device connected:" << macAddress;
+            }
+            else
+            {
+                emit deviceDisconnected(macAddress);
+                qDebug() << "Device disconnected:" << macAddress;
+            }
+        }
+    }
+}

--- a/linux/BluetoothMonitor.h
+++ b/linux/BluetoothMonitor.h
@@ -1,0 +1,26 @@
+#ifndef BLUETOOTHMONITOR_H
+#define BLUETOOTHMONITOR_H
+
+#include <QObject>
+#include <QtDBus/QtDBus>
+
+class BluetoothMonitor : public QObject, protected QDBusContext
+{
+    Q_OBJECT
+public:
+    explicit BluetoothMonitor(QObject *parent = nullptr);
+    ~BluetoothMonitor();
+
+signals:
+    void deviceConnected(const QString &macAddress);
+    void deviceDisconnected(const QString &macAddress);
+
+private slots:
+    void onPropertiesChanged(const QString &interface, const QVariantMap &changedProps, const QStringList &invalidatedProps);
+
+private:
+    QDBusConnection m_dbus;
+    void registerDBusService();
+};
+
+#endif // BLUETOOTHMONITOR_H

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -19,6 +19,8 @@ qt_add_executable(applinux
     trayiconmanager.h
     enums.h
     battery.hpp
+    BluetoothMonitor.cpp
+    BluetoothMonitor.h
 )
 
 qt_add_qml_module(applinux

--- a/linux/SegmentedControl.qml
+++ b/linux/SegmentedControl.qml
@@ -53,6 +53,18 @@ Control {
                 height: root.availableHeight
                 focusPolicy: Qt.NoFocus // Let the root control handle focus
 
+                // Add explicit text color
+                contentItem: Text {
+                    text: segmentButton.text
+                    font: segmentButton.font
+                    color: root.currentIndex === segmentButton.index ? root.selectedTextColor : root.textColor
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    leftPadding: 2
+                    rightPadding: 2
+                    elide: Text.ElideRight
+                }
+
                 background: Rectangle {
                     radius: height / 2
                     color: root.currentIndex === segmentButton.index ? root.selectedColor : "transparent"

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -57,8 +57,8 @@ public:
         mediaController->initializeMprisInterface();
         mediaController->followMediaChanges();
 
-        connect(monitor, &BluetoothMonitor::deviceConnected, this, static_cast<void (AirPodsTrayApp::*)(const QString &)>(&AirPodsTrayApp::onDeviceConnected));
-        connect(monitor, &BluetoothMonitor::deviceDisconnected, this, static_cast<void (AirPodsTrayApp::*)(const QString &)>(&AirPodsTrayApp::onDeviceDisconnected));
+        connect(monitor, &BluetoothMonitor::deviceConnected, this, &AirPodsTrayApp::bluezDeviceConnected);
+        connect(monitor, &BluetoothMonitor::deviceDisconnected, this, &AirPodsTrayApp::bluezDeviceDisconnected);
 
         connect(m_battery, &Battery::primaryChanged, this, &AirPodsTrayApp::primaryChanged);
 
@@ -83,15 +83,6 @@ public:
             }
         }
 
-        QDBusInterface iface("org.bluez", "/org/bluez", "org.bluez.Adapter1");
-        QDBusReply<QVariant> reply = iface.call("GetServiceRecords", QString::fromUtf8("74ec2172-0bad-4d01-8f77-997b2be0722a"));
-        if (reply.isValid()) {
-            LOG_INFO("Service record found, proceeding with connection");
-        } else {
-            LOG_WARN("Service record not found, waiting for BLE broadcast");
-        }
-
-        listenForDeviceConnections();
         initializeDBus();
         initializeBluetooth();
     }
@@ -102,8 +93,6 @@ public:
         delete trayIcon;
         delete trayMenu;
         delete discoveryAgent;
-        delete bluezInterface;
-        delete mprisInterface;
         delete socket;
         delete phoneSocket;
     }
@@ -142,46 +131,7 @@ private:
         bool isEnabled = true; // Ability to disable the feature
     } CrossDevice;
 
-    void initializeDBus() {
-        QDBusConnection systemBus = QDBusConnection::systemBus();
-        if (!systemBus.isConnected()) {
-        }
-
-        bluezInterface = new QDBusInterface("org.bluez",
-                                        "/",
-                                        "org.freedesktop.DBus.ObjectManager",
-                                        systemBus,
-                                        this);
-
-        if (!bluezInterface->isValid()) {
-            LOG_ERROR("Failed to connect to org.bluez DBus interface.");
-            return;
-        }
-
-        connect(systemBus.interface(), &QDBusConnectionInterface::NameOwnerChanged,
-                this, &AirPodsTrayApp::onNameOwnerChanged);
-
-        systemBus.connect(QString(), QString(), "org.freedesktop.DBus.Properties", "PropertiesChanged",
-                        this, SLOT(onDevicePropertiesChanged(QString, QVariantMap, QStringList)));
-
-        systemBus.connect(QString(), QString(), "org.freedesktop.DBus.ObjectManager", "InterfacesAdded",
-                        this, SLOT(onInterfacesAdded(QString, QVariantMap)));
-
-        QDBusMessage msg = bluezInterface->call("GetManagedObjects");
-        if (msg.type() == QDBusMessage::ErrorMessage) {
-            LOG_ERROR("Error getting managed objects: " << msg.errorMessage());
-            return;
-        }
-
-        QVariantMap objects = qdbus_cast<QVariantMap>(msg.arguments().at(0));
-        for (auto it = objects.begin(); it != objects.end(); ++it) {
-            if (it.key().startsWith("/org/bluez/hci0/dev_")) {
-                LOG_INFO("Existing device: " << it.key());
-            }
-        }
-        QDBusConnection::systemBus().registerObject("/me/kavishdevar/aln", this);
-        QDBusConnection::systemBus().registerService("me.kavishdevar.aln");
-    }
+    void initializeDBus() { }
 
     bool isAirPodsDevice(const QBluetoothDeviceInfo &device)
     {
@@ -200,42 +150,10 @@ private:
             LOG_WARN("Phone socket is not open, cannot send notification packet");
         }
     }
-    void onNameOwnerChanged(const QString &name, const QString &oldOwner, const QString &newOwner) {
-        if (name == "org.bluez") {
-            if (newOwner.isEmpty()) {
-                LOG_WARN("BlueZ has been stopped.");
-            } else {
-                LOG_INFO("BlueZ started.");
-            }
-        }
-    }
-
-    void onDevicePropertiesChanged(const QString &interface, const QVariantMap &changed, const QStringList &invalidated) {
-        if (interface != "org.bluez.Device1")
-            return;
-
-        if (changed.contains("Connected")) {
-            bool connected = changed.value("Connected").toBool();
-            QString devicePath = sender()->objectName();
-            LOG_INFO(QString("Device %1 connected: %2").arg(devicePath, connected ? "Yes" : "No"));
-
-            if (connected) {
-                const QBluetoothAddress address = QBluetoothAddress(devicePath.split("/").last().replace("_", ":"));
-                QBluetoothDeviceInfo device(address, "", 0);
-                if (isAirPodsDevice(device)) {
-                    connectToDevice(device);
-                }
-            } else {
-                disconnectDevice(devicePath);
-            }
-        }
-    }
 
     void disconnectDevice(const QString &devicePath) {
         LOG_INFO("Disconnecting device at " << devicePath);
     }
-
-    QDBusInterface *bluezInterface = nullptr;
 
 public slots:
     void connectToDevice(const QString &address) {
@@ -427,7 +345,11 @@ private slots:
             connectToDevice(device);
         }
     }
-    void onDeviceConnected(const QString &address) { onDeviceConnected(QBluetoothAddress(address)); }
+    void bluezDeviceConnected(const QString &address) 
+    {
+        QBluetoothDeviceInfo device(QBluetoothAddress(address), "", 0);
+        connectToDevice(device);
+    }
 
     void onDeviceDisconnected(const QBluetoothAddress &address)
     {
@@ -445,7 +367,15 @@ private slots:
             LOG_DEBUG("AIRPODS_DISCONNECTED packet written: " << AirPodsPackets::Connection::AIRPODS_DISCONNECTED.toHex());
         }
     }
-    void onDeviceDisconnected(const QString &address) { onDeviceDisconnected(QBluetoothAddress(address)); }
+    void bluezDeviceDisconnected(const QString &address) 
+    {
+        if (address == connectedDeviceMacAddress.replace("_", ":")) {
+            onDeviceDisconnected(QBluetoothAddress(address));
+        }
+        else {
+            LOG_WARN("Disconnected device does not match connected device: " << address << " != " << connectedDeviceMacAddress);
+        }
+    }
 
     void parseMetadata(const QByteArray &data)
     {
@@ -532,9 +462,6 @@ private slots:
 
         LOG_INFO("Connecting to device: " << device.name());
         QBluetoothSocket *localSocket = new QBluetoothSocket(QBluetoothServiceInfo::L2capProtocol);
-        connect(localSocket, &QBluetoothSocket::disconnected, this, [this, localSocket]() {
-            onDeviceDisconnected(localSocket->peerAddress());
-        });
         connect(localSocket, &QBluetoothSocket::connected, this, [this, localSocket]() {
             // Start periodic magic pairing attempts
             QTimer *magicPairingTimer = new QTimer(this);
@@ -786,26 +713,6 @@ private slots:
         QMetaObject::invokeMethod(this, "handlePhonePacket", Qt::QueuedConnection, Q_ARG(QByteArray, data));
     }
 
-    void listenForDeviceConnections() {
-        QDBusConnection systemBus = QDBusConnection::systemBus();
-        systemBus.connect(QString(), QString(), "org.freedesktop.DBus.Properties", "PropertiesChanged", this, SLOT(onDevicePropertiesChanged(QString, QVariantMap, QStringList)));
-        systemBus.connect(QString(), QString(), "org.freedesktop.DBus.ObjectManager", "InterfacesAdded", this, SLOT(onInterfacesAdded(QString, QVariantMap)));
-    }
-
-    void onInterfacesAdded(QString path, QVariantMap interfaces) {
-        if (interfaces.contains("org.bluez.Device1")) {
-            QVariantMap deviceProps = interfaces["org.bluez.Device1"].toMap();
-            if (deviceProps.contains("Connected") && deviceProps["Connected"].toBool()) {
-                QString addr = deviceProps["Address"].toString();
-                QBluetoothAddress btAddress(addr);
-                QBluetoothDeviceInfo device(btAddress, "", 0);
-                if (isAirPodsDevice(device)) {
-                    connectToDevice(device);
-                }
-            }
-        }
-    }
-
     public:
         void handleMediaStateChange(MediaController::MediaState state) {
             if (state == MediaController::MediaState::Playing) {
@@ -911,7 +818,6 @@ private:
     QBluetoothDeviceDiscoveryAgent *discoveryAgent;
     QBluetoothSocket *socket = nullptr;
     QBluetoothSocket *phoneSocket = nullptr;
-    QDBusInterface *mprisInterface;
     QString connectedDeviceMacAddress;
     QByteArray lastBatteryStatus;
     QByteArray lastEarDetectionStatus;


### PR DESCRIPTION
By watching the bluz dbus, we now have proper disconnection detection.

The previous code did not work, for l2cap sockets, Qt's disconnected event isn't emitted reliably.

This code even triggers when we disable bluetooth.

#### Fixed:
- [x] Disconnection was not detected
- [x] Automatically allow reconnecting (no need to restart app anymore)
- [x] Fixed text not visible in SegmentedControl in release builds (it worked in debug builds??)