### PR TITLE
[Linux] Improve connection stability

### DIFF
--- a/linux/BluetoothMonitor.cpp
+++ b/linux/BluetoothMonitor.cpp
@@ -2,10 +2,16 @@
 #include "logger.h"
 
 #include <QDebug>
+#include <QDBusObjectPath>
+#include <QDBusMetaType>
 
-BluetoothMonitor::BluetoothMonitor(QObject *parent) 
+BluetoothMonitor::BluetoothMonitor(QObject *parent)
     : QObject(parent), m_dbus(QDBusConnection::systemBus())
 {
+    // Register meta-types for D-Bus interaction
+    qDBusRegisterMetaType<QDBusObjectPath>();
+    qDBusRegisterMetaType<ManagedObjectList>();
+
     if (!m_dbus.isConnected())
     {
         LOG_WARN("Failed to connect to system D-Bus");
@@ -13,6 +19,7 @@ BluetoothMonitor::BluetoothMonitor(QObject *parent)
     }
 
     registerDBusService();
+    checkAlreadyConnectedDevices(); // Check for already connected devices on startup
 }
 
 BluetoothMonitor::~BluetoothMonitor()
@@ -23,23 +30,91 @@ BluetoothMonitor::~BluetoothMonitor()
 void BluetoothMonitor::registerDBusService()
 {
     // Match signals for PropertiesChanged on any BlueZ Device interface
-    QString matchRule = QStringLiteral("type='signal',"
-                                       "interface='org.freedesktop.DBus.Properties',"
-                                       "member='PropertiesChanged',"
-                                       "path_namespace='/org/bluez'");
-
-    m_dbus.connect("org.freedesktop.DBus",
-                   "/org/freedesktop/DBus",
-                   "org.freedesktop.DBus",
-                   "AddMatch",
-                   this,
-                   SLOT(onPropertiesChanged(QString, QVariantMap, QStringList)));
-
     if (!m_dbus.connect("", "", "org.freedesktop.DBus.Properties", "PropertiesChanged",
                         this, SLOT(onPropertiesChanged(QString, QVariantMap, QStringList))))
     {
         LOG_WARN("Failed to connect to D-Bus PropertiesChanged signal");
     }
+}
+
+bool BluetoothMonitor::isAirPodsDevice(const QString &devicePath)
+{
+    QDBusInterface deviceInterface("org.bluez", devicePath, "org.freedesktop.DBus.Properties", m_dbus);
+
+    // Get UUIDs to check if it's an AirPods device
+    QDBusReply<QVariant> uuidsReply = deviceInterface.call("Get", "org.bluez.Device1", "UUIDs");
+    if (!uuidsReply.isValid())
+    {
+        return false;
+    }
+
+    QStringList uuids = uuidsReply.value().toStringList();
+    return uuids.contains("74ec2172-0bad-4d01-8f77-997b2be0722a");
+}
+
+QString BluetoothMonitor::getDeviceName(const QString &devicePath)
+{
+    QDBusInterface deviceInterface("org.bluez", devicePath, "org.freedesktop.DBus.Properties", m_dbus);
+    QDBusReply<QVariant> nameReply = deviceInterface.call("Get", "org.bluez.Device1", "Name");
+    if (nameReply.isValid())
+    {
+        return nameReply.value().toString();
+    }
+    return "Unknown";
+}
+
+bool BluetoothMonitor::checkAlreadyConnectedDevices()
+{
+    QDBusInterface objectManager("org.bluez", "/", "org.freedesktop.DBus.ObjectManager", m_dbus);
+    QDBusMessage reply = objectManager.call("GetManagedObjects");
+
+    if (reply.type() == QDBusMessage::ErrorMessage)
+    {
+        LOG_WARN("Failed to get managed objects: " << reply.errorMessage());
+        return false;
+    }
+
+    QVariant firstArg = reply.arguments().constFirst();
+    QDBusArgument arg = firstArg.value<QDBusArgument>();
+    ManagedObjectList managedObjects;
+    arg >> managedObjects;
+
+    bool deviceFound = false;
+
+    for (auto it = managedObjects.constBegin(); it != managedObjects.constEnd(); ++it)
+    {
+        const QDBusObjectPath &objPath = it.key();
+        const QMap<QString, QVariantMap> &interfaces = it.value();
+
+        if (interfaces.contains("org.bluez.Device1"))
+        {
+            const QVariantMap &deviceProps = interfaces.value("org.bluez.Device1");
+
+            // Check if the device has the necessary properties
+            if (!deviceProps.contains("UUIDs") || !deviceProps.contains("Connected") ||
+                !deviceProps.contains("Address") || !deviceProps.contains("Name"))
+            {
+                continue;
+            }
+
+            QStringList uuids = deviceProps["UUIDs"].toStringList();
+            bool isAirPods = uuids.contains("74ec2172-0bad-4d01-8f77-997b2be0722a");
+
+            if (isAirPods)
+            {
+                bool connected = deviceProps["Connected"].toBool();
+                if (connected)
+                {
+                    QString macAddress = deviceProps["Address"].toString();
+                    QString deviceName = deviceProps["Name"].toString();
+                    emit deviceConnected(macAddress, deviceName);
+                    LOG_DEBUG("Found already connected AirPods: " << macAddress << " Name: " << deviceName);
+                    deviceFound = true;
+                }
+            }
+        }
+    }
+    return deviceFound;
 }
 
 void BluetoothMonitor::onPropertiesChanged(const QString &interface, const QVariantMap &changedProps, const QStringList &invalidatedProps)
@@ -56,8 +131,13 @@ void BluetoothMonitor::onPropertiesChanged(const QString &interface, const QVari
         bool connected = changedProps["Connected"].toBool();
         QString path = QDBusContext::message().path();
 
+        if (!isAirPodsDevice(path))
+        {
+            return;
+        }
+
         QDBusInterface deviceInterface("org.bluez", path, "org.freedesktop.DBus.Properties", m_dbus);
-        
+
         // Get the device address
         QDBusReply<QVariant> addrReply = deviceInterface.call("Get", "org.bluez.Device1", "Address");
         if (!addrReply.isValid())
@@ -65,29 +145,17 @@ void BluetoothMonitor::onPropertiesChanged(const QString &interface, const QVari
             return;
         }
         QString macAddress = addrReply.value().toString();
-
-        // Get UUIDs to check if it's an AirPods device
-        QDBusReply<QVariant> uuidsReply = deviceInterface.call("Get", "org.bluez.Device1", "UUIDs");
-        if (!uuidsReply.isValid())
-        {
-            return;
-        }
-
-        QStringList uuids = uuidsReply.value().toStringList();
-        if (!uuids.contains("74ec2172-0bad-4d01-8f77-997b2be0722a"))
-        {
-            return; // Not an AirPods device
-        }
+        QString deviceName = getDeviceName(path);
 
         if (connected)
         {
-            emit deviceConnected(macAddress);
-            LOG_DEBUG("AirPods device connected:" << macAddress);
+            emit deviceConnected(macAddress, deviceName);
+            LOG_DEBUG("AirPods device connected:" << macAddress << " Name:" << deviceName);
         }
         else
         {
-            emit deviceDisconnected(macAddress);
-            LOG_DEBUG("AirPods device disconnected:" << macAddress);
+            emit deviceDisconnected(macAddress, deviceName);
+            LOG_DEBUG("AirPods device disconnected:" << macAddress << " Name:" << deviceName);
         }
     }
 }

--- a/linux/BluetoothMonitor.h
+++ b/linux/BluetoothMonitor.h
@@ -4,6 +4,10 @@
 #include <QObject>
 #include <QtDBus/QtDBus>
 
+// Forward declarations for D-Bus types
+typedef QMap<QDBusObjectPath, QMap<QString, QVariantMap>> ManagedObjectList;
+Q_DECLARE_METATYPE(ManagedObjectList)
+
 class BluetoothMonitor : public QObject, protected QDBusContext
 {
     Q_OBJECT
@@ -11,9 +15,11 @@ public:
     explicit BluetoothMonitor(QObject *parent = nullptr);
     ~BluetoothMonitor();
 
+    bool checkAlreadyConnectedDevices();
+
 signals:
-    void deviceConnected(const QString &macAddress);
-    void deviceDisconnected(const QString &macAddress);
+    void deviceConnected(const QString &macAddress, const QString &deviceName);
+    void deviceDisconnected(const QString &macAddress, const QString &deviceName);
 
 private slots:
     void onPropertiesChanged(const QString &interface, const QVariantMap &changedProps, const QStringList &invalidatedProps);
@@ -21,6 +27,8 @@ private slots:
 private:
     QDBusConnection m_dbus;
     void registerDBusService();
+    bool isAirPodsDevice(const QString &devicePath);
+    QString getDeviceName(const QString &devicePath);
 };
 
 #endif // BLUETOOTHMONITOR_H

--- a/linux/Main.qml
+++ b/linux/Main.qml
@@ -104,6 +104,7 @@ ApplicationWindow {
             model: ["Off", "Noise Cancellation", "Transparency", "Adaptive"]
             currentIndex: airPodsTrayApp.noiseControlMode
             onCurrentIndexChanged: airPodsTrayApp.noiseControlMode = currentIndex
+            visible: airPodsTrayApp.airpodsConnected
         }
 
         Text {


### PR DESCRIPTION
For me the old method with QBluetoothDeviceDiscoveryAgent the connecting was pretty unstable.
It was disconnecting after a short amount of time, always. Since we already rely on BlueZ (only supported backend in Qt for Linux), I use the bluez dbus api to check for connected/disconnected devices.

Our Qt code than only connects to the service, not the device itself.

With this change I noticed a improvement in the time it takes for the app to connect to the airpods.

It's a pretty big change, and I wanna know what you think about it (@kavishdevar). I only noticed improvements. 

Upsides I know of:
- Improved connection speed
- Improved connection reliability
- Reduced resource usage (for my debug build, CPU usage not even measurable, RAM 102.4 MiB)

Possible downsides:
- App doesn't auto-connect to airpods (since the system decides it). We could implement it