### PR TITLE
[Linux] Dynamically find device sink name

### DIFF
--- a/linux/mediacontroller.cpp
+++ b/linux/mediacontroller.cpp
@@ -262,7 +262,7 @@ QString MediaController::getAudioDeviceName()
 
   // Set up QProcess to run pactl directly
   QProcess process;
-  process.start("pactl", QStringList() << "list" << "sinks" << "short");
+  process.start("pactl", QStringList() << "list" << "cards" << "short");
   if (!process.waitForFinished(3000)) // Timeout after 3 seconds
   {
     LOG_ERROR("pactl command failed or timed out: " << process.errorString());

--- a/linux/mediacontroller.cpp
+++ b/linux/mediacontroller.cpp
@@ -218,6 +218,7 @@ void MediaController::removeAudioOutputDevice() {
 void MediaController::setConnectedDeviceMacAddress(const QString &macAddress) {
   connectedDeviceMacAddress = macAddress;
   m_deviceOutputName = getAudioDeviceName();
+  LOG_INFO("Device output name set to: " << m_deviceOutputName);
 }
 
 MediaController::MediaState MediaController::mediaStateFromPlayerctlOutput(

--- a/linux/mediacontroller.h
+++ b/linux/mediacontroller.h
@@ -47,6 +47,7 @@ Q_SIGNALS:
 
 private:
   MediaState mediaStateFromPlayerctlOutput(const QString &output);
+  QString getAudioDeviceName();
 
   QDBusInterface *mprisInterface = nullptr;
   QProcess *playerctlProcess = nullptr;
@@ -54,6 +55,7 @@ private:
   int initialVolume = -1;
   QString connectedDeviceMacAddress;
   EarDetectionBehavior earDetectionBehavior = PauseWhenOneRemoved;
+  QString m_deviceOutputName;
 };
 
 #endif // MEDIACONTROLLER_H


### PR DESCRIPTION
Should fix #107, needs testing (works for me)

Should work on pipewire and pulseaudio systems.