### PR TITLE
[Linux] Add CLI flag to hide the window on startup

### DIFF
--- a/linux/Main.qml
+++ b/linux/Main.qml
@@ -5,7 +5,7 @@ import QtQuick.Controls 2.15
 
 ApplicationWindow {
     id: mainWindow
-    visible: true
+    visible: !airPodsTrayApp.hideOnStart
     width: 400
     height: 300
     title: "AirPods Settings"


### PR DESCRIPTION
I like to start this program when connecting to my AirPods and it isn't necessary for me to have the window pop up. Therefore, using the --hide flag when starting the program will hide the window on startup.

This could also be a configuration option (e.g. 'Start minimized') but I went with the CLI flag for simplicity for now. However, if this is a more viable option (and it may be better in the future), I can implement this as an option in the settings instead.