### PR TITLE
[Linux] Add seperators to tray, add tray option to reopen app and settings, prevent duplicate instances of app from being opened

### DIFF
--- a/linux/Main.qml
+++ b/linux/Main.qml
@@ -9,8 +9,32 @@ ApplicationWindow {
     width: 400
     height: 300
     title: "AirPods Settings"
+    objectName: "mainWindowObject"
 
     onClosing: mainWindow.visible = false
+
+    function reopen(pageToLoad) {
+        if (pageToLoad == "settings")
+        {
+            if (stackView.depth == 1)
+            {
+                stackView.push(settingsPage)
+            }
+        }
+        else
+        {
+            if (stackView.depth > 1)
+            {
+                stackView.pop()
+            }
+        }
+
+        if (!mainWindow.visible) {
+            mainWindow.visible = true
+        }
+        raise()
+        requestActivate()
+    }
 
     // Mouse area for handling back/forward navigation
     MouseArea {

--- a/linux/trayiconmanager.cpp
+++ b/linux/trayiconmanager.cpp
@@ -56,12 +56,27 @@ void TrayIconManager::updateConversationalAwareness(bool enabled)
 
 void TrayIconManager::setupMenuActions()
 {
+    // Open action
+    QAction *openAction = new QAction("Open", trayMenu);
+    trayMenu->addAction(openAction);
+    connect(openAction, &QAction::triggered, qApp, [this](){emit openApp();});
+
+    // Settings Menu
+
+    QAction *settingsMenu = new QAction("Settings", trayMenu);
+    trayMenu->addAction(settingsMenu);
+    connect(settingsMenu, &QAction::triggered, qApp, [this](){emit openSettings();});
+
+    trayMenu->addSeparator();
+
     // Conversational Awareness Toggle
     caToggleAction = new QAction("Toggle Conversational Awareness", trayMenu);
     caToggleAction->setCheckable(true);
     trayMenu->addAction(caToggleAction);
     connect(caToggleAction, &QAction::triggered, this, [this](bool checked)
             { emit conversationalAwarenessToggled(checked); });
+
+    trayMenu->addSeparator();
 
     // Noise Control Options
     noiseControlGroup = new QActionGroup(trayMenu);
@@ -81,6 +96,8 @@ void TrayIconManager::setupMenuActions()
         connect(action, &QAction::triggered, this, [this, mode = option.second]()
                 { emit noiseControlChanged(mode); });
     }
+
+    trayMenu->addSeparator();
 
     // Quit action
     QAction *quitAction = new QAction("Quit", trayMenu);

--- a/linux/trayiconmanager.h
+++ b/linux/trayiconmanager.h
@@ -54,4 +54,6 @@ signals:
     void trayClicked();
     void noiseControlChanged(AirpodsTrayApp::Enums::NoiseControlMode);
     void conversationalAwarenessToggled(bool enabled);
+    void openApp();
+    void openSettings();
 };


### PR DESCRIPTION
This pull request would add additional functionality and quality of life enhancements to the Linux application:
- Allows for an existing app instance to be reopened from the app tray to the main app menu or settings menu
- Add separators between different options in tray to improve clarity
- Add detection for existing app instances and the ability for a duplicate instance to trigger a reopening of the original app instance instead of spinning up a new instance

This improves functionality for an end user by adding in expected responses to app interactions.

Edit:
Additional changes made since original pull request:
- Add error handling for socket and server
- Use environment variable instead of preprocessor to detect 
- Clear variable on original instance quitting
- Proper handling in case connection refused for duplicate client